### PR TITLE
fix: updating arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- fix: updating arrays #2
 
 ## [0.2.0] - 2023-01-09
 ### Changed

--- a/package.json
+++ b/package.json
@@ -65,12 +65,10 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "create-react-signals": "0.1.0",
-    "ramda": "^0.28.0"
+    "create-react-signals": "0.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.5",
-    "@types/ramda": "^0.28.20",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
     "@typescript-eslint/eslint-plugin": "^5.48.0",

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -42,19 +42,18 @@ type SetValue = (path: unknown[], value: unknown) => void;
 
 const identity = <T>(x: T): T => x;
 
-const updateValue = (obj: unknown, path: unknown[], value: unknown) => {
+const updateValue = (obj: any, path: unknown[], value: unknown) => {
   if (!path.length) {
     return value;
   }
-  const first = path[0] as string;
-  const rest = path.slice(1);
-  const prevValue = (obj as any)[first];
+  const [first, ...rest] = path;
+  const prevValue = obj[first as string];
   const nextValue = updateValue(prevValue, rest, value);
   if (Object.is(prevValue, nextValue)) {
     return obj;
   }
-  const copied = Array.isArray(obj) ? obj.slice() : { ...(obj as any) };
-  copied[first] = nextValue;
+  const copied = Array.isArray(obj) ? obj.slice() : { ...obj };
+  copied[first as string] = nextValue;
   return copied;
 };
 
@@ -89,7 +88,7 @@ const createSignal = <T, S>(
     if (selector !== identity) {
       throw new Error('Cannot set a value with a selector');
     }
-    store.setState((prev) => updateValue(prev, path, value));
+    store.setState((prev) => updateValue(prev, path, value), true);
   };
   return [sub, get, set];
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,13 +1654,6 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/ramda@^0.28.20":
-  version "0.28.20"
-  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.28.20.tgz#df93bb5674f0051464c075480ca3075d1c1361ba"
-  integrity sha512-MeUhzGSXQTRsY19JGn5LIBTLxVEnyF6HDNr08KSJqybsm4DlfLIgK1jBHjhpiSyk252tXYmp+UOe0UFg0UiFsA==
-  dependencies:
-    ts-toolbelt "^6.15.1"
-
 "@types/range-parser@*":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
@@ -6249,11 +6242,6 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-ramda@^0.28.0:
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.28.0.tgz#acd785690100337e8b063cab3470019be427cc97"
-  integrity sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==
-
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -7208,11 +7196,6 @@ ts-loader@^9.4.2:
     enhanced-resolve "^5.0.0"
     micromatch "^4.0.0"
     semver "^7.3.4"
-
-ts-toolbelt@^6.15.1:
-  version "6.15.5"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
-  integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
 
 tsconfig-paths@^3.14.1:
   version "3.14.1"


### PR DESCRIPTION
From proxies, path are `(string | symbol)[]`, so we can't update arrays properly like objects. This should fix it.